### PR TITLE
Added ability to auto select whole word

### DIFF
--- a/turboConsoleLog.js
+++ b/turboConsoleLog.js
@@ -15,8 +15,27 @@ function activate(context) {
     const tabSize = editor.options.tabSize;
     const document = editor.document;
     const selection = editor.selection;
-    const selectedVar = document.getText(selection);
+    let selectedVar = document.getText(selection);
     const lineOfSelectedVar = selection.active.line;
+
+    // If selected range is empty, then select whole word
+    if (!selectedVar) {
+      const wordRangeAtSelection = document.getWordRangeAtPosition(
+        selection.active
+      );
+
+      if (wordRangeAtSelection) {
+        const selectedWordRange = new vscode.Selection(
+          wordRangeAtSelection.start.line,
+          wordRangeAtSelection.start.character,
+          wordRangeAtSelection.end.line,
+          wordRangeAtSelection.end.character
+        );
+        editor.selection = selectedWordRange;
+        selectedVar = document.getText(selectedWordRange);
+      }
+    }
+
     // Check if the selection line is not the last one in the document and the selected variable is not empty
     if (
       !(lineOfSelectedVar === document.lineCount - 1) &&


### PR DESCRIPTION
Sometimes I'm place caret at center of the word and TurboConsoleLog cannot create log message.

I'm added a fix for this, using internal VSCode methods.

Feel free to CR my code, probably some moments is not very clear for understanding.

Example of using:
![turbo-console-log](https://user-images.githubusercontent.com/1858708/51513846-2ab43b00-1e37-11e9-8701-5ead0ed8cdb7.gif)
