### PR TITLE
Add namespace to configuration names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ console.log("SelectedVariableEnclosingClassName -> SelectedVariableEnclosingFunc
 
 Properties:
 
-- wrapLogMessage (boolean): Whether to wrap the log message or not.
+- turboConsoleLog.wrapLogMessage (boolean): Whether to wrap the log message or not.
 
-- logMessagePrefix (string): The prefix of the log message, default one is TCL.
+- turboConsoleLog.logMessagePrefix (string): The prefix of the log message, default one is TCL.
 
-- addSemicolonInTheEnd (boolean): Whether to put a semicolon in the end of the log message or not.
+- turboConsoleLog.addSemicolonInTheEnd (boolean): Whether to put a semicolon in the end of the log message or not.
 
-- quote (enum): Double quotes (""), single quotes ('') or backtick(``). 
+- turboConsoleLog.quote (enum): Double quotes (""), single quotes ('') or backtick(``).
 
 A wrapped log message :
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "turbo-console-log",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,24 +23,28 @@
       "type": "object",
       "title": "Turbo Console Log Configuration",
       "properties": {
-        "wrapLogMessage": {
+        "turboConsoleLog.wrapLogMessage": {
           "type": "boolean",
           "default": false,
           "description": "Determine if the log message should be wrapped or not."
         },
-        "logMessagePrefix": {
+        "turboConsoleLog.logMessagePrefix": {
           "type": "string",
           "default": "TCL",
           "description": "The prefix of the log message."
         },
-        "addSemicolonInTheEnd": {
+        "turboConsoleLog.addSemicolonInTheEnd": {
           "type": "boolean",
           "default": false,
           "description": "Whether to add or not a semicolon in the end of the log message."
         },
-        "quote": {
+        "turboConsoleLog.quote": {
           "type": "string",
-          "enum": ["\"", "'", "`"],
+          "enum": [
+            "\"",
+            "'",
+            "`"
+          ],
           "default": "\"",
           "description": "Double quotes, single quotes or backtick"
         }

--- a/turboConsoleLog.js
+++ b/turboConsoleLog.js
@@ -23,13 +23,12 @@ function activate(context) {
       selectedVar.trim().length !== 0
     ) {
       editor.edit(editBuilder => {
-        const wrapLogMessage =
-          vscode.workspace.getConfiguration().wrapLogMessage || false;
-        const logMessagePrefix = vscode.workspace.getConfiguration()
-          .logMessagePrefix;
-        const quote = vscode.workspace.getConfiguration().quote;
-        const addSemicolonInTheEnd =
-          vscode.workspace.getConfiguration().addSemicolonInTheEnd || false;
+        const config = vscode.workspace.getConfiguration("turboConsoleLog");
+        const wrapLogMessage = config.wrapLogMessage || false;
+        const logMessagePrefix = config.logMessagePrefix;
+        const quote = config.quote;
+        const addSemicolonInTheEnd = config.addSemicolonInTheEnd || false;
+
         editBuilder.insert(
           new vscode.Position(lineOfSelectedVar + 1, 0),
           logMessage.message(
@@ -56,7 +55,7 @@ function activate(context) {
       const tabSize = editor.options.tabSize;
       const document = editor.document;
       const logMessagePrefix =
-        vscode.workspace.getConfiguration().logMessagePrefix || "TCL";
+        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix || "TCL";
       const logMessages = logMessage.detectAll(
         document,
         tabSize,
@@ -86,7 +85,7 @@ function activate(context) {
       const tabSize = editor.options.tabSize;
       const document = editor.document;
       const logMessagePrefix =
-        vscode.workspace.getConfiguration().logMessagePrefix || "TCL";
+        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix || "TCL";
       const logMessages = logMessage.detectAll(
         document,
         tabSize,
@@ -118,7 +117,7 @@ function activate(context) {
       const tabSize = editor.options.tabSize;
       const document = editor.document;
       const logMessagePrefix =
-        vscode.workspace.getConfiguration().logMessagePrefix || "TCL";
+        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix || "TCL";
       const logMessages = logMessage.detectAll(
         document,
         tabSize,


### PR DESCRIPTION
Solution for Issue #50 

Adds turboConsoleLog prefix to the four configuration settings:
```json
{
  "turboConsoleLog.wrapLogMessage": false,
  "turboConsoleLog.logMessagePrefix": "TCL",
  "turboConsoleLog.addSemicolonInTheEnd": false,
  "turboConsoleLog.quote": false
}
```
Updated package.json and README.md to match.