### PR TITLE
Added Ability to Correctly Parse FunctionName From Typescript Methods…

### DIFF
--- a/line-code-processing.js
+++ b/line-code-processing.js
@@ -40,7 +40,7 @@ function className(lineCode) {
  * @since 1.0
  */
 function checkIfNamedFunction(lineCode) {
-  const namedFunctionDeclarationRegex = /[a-zA-Z]+(\s*)\(.*\)(\s*){/;
+  const namedFunctionDeclarationRegex = /[a-zA-Z]+(\s*)\(.*\)(.*){/;
   const nonNamedFunctionDeclaration = /(function)(\s*)\(.*\)(\s*){/;
   const namedFunctionExpressionRegex = /[a-zA-Z]+(\s*)=(\s*)(function)?(\s*)[a-zA-Z]*(\s*)\(.*\)(\s*)(=>)?(\s*){/;
   const isNamedFunctionDeclaration = namedFunctionDeclarationRegex.test(
@@ -95,7 +95,7 @@ function functionName(lineCode) {
             .replace(/export |module.exports |const |var |let |=|(\s*)/g, "");
         }
       } else {
-        return textInTheLeftOfTheParams.replace(/async |(\s*)/g, "");
+        return textInTheLeftOfTheParams.replace(/async|public|private|protected|static|export |(\s*)/g, "");
       }
     }
   }

--- a/test/line-code-processing.test.js
+++ b/test/line-code-processing.test.js
@@ -24,7 +24,16 @@ describe("Source Code Processing", () => {
     "functionName = (arg1, arg2) => {",
     "functionName = function otherName (arg1, arg2) => {",
     "array.forEach(function functionName() {",
-    "export const functionName = (arg1, arg2) => {"
+    "export const functionName = (arg1, arg2) => {",
+    "functionName(arg1: any): any {",
+    "async functionName(arg1: any): any {",
+    "public functionName(arg1: any): any {",
+    "public async functionName(arg1: any): any {",
+    "public static functionName(arg1: any): any {",
+    "private functionName(arg1: any): any {",
+    "protected functionName(arg1: any): any {",
+    "static functionName(arg1: any): any {",
+    "export functionName(arg1: any): any {",
   ];
   const nonNamedFunctions = [
     "function() {",


### PR DESCRIPTION
…/Functions

- Updated namedFunctionDeclarationRegex to Allow any Character rather than just spaces after closing )
- Updated regex used when parsing out function name to strip out typescript access modifiies and the export keywork in addition to the async word already being striped out
- Updated test to cover new test cases