### PR TITLE
Add custom styling option for each block

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ All it takes to delete all log messages, inserted by the extension, from the cur
 
 ![alt text](https://image.ibb.co/jv9UtU/delete_all_log_messages.gif "Delete all log messages, inserted by the extension, from the current file")
 
+V) Add styling options for each part of the variable's path definition.
+
+Properties:
+
+- turboConsoleLog.styleArray (string[], max 3): a list of CSS stylings, to be applied to prefix, class/function and variable name.
+
 **_Warning:_**
 
 The extension rely on the log message prefix in order to detect the generated log messages, missing up the prefix will result on the failure of the detection and hence the failure of commenting, uncommenting and deleting the log messages.

--- a/log-message.js
+++ b/log-message.js
@@ -31,7 +31,7 @@ function message(
   tabSize,
   styleArray
 ) {
-  const optionalStyleDirective = styleArray.length ? "%c" : "";
+  const optionalStyleDirective = styleArray.length ? "%c " : "";
   const classThatEncloseTheVar = enclosingBlockName(
     document,
     lineOfSelectedVar,
@@ -44,17 +44,26 @@ function message(
     "function",
     optionalStyleDirective
   );
-  const formattedStyleArray =
-    (styleArray.length ? ", " : "") +
-    styleArray
-      .slice(
-        0,
-        2 +
-          (insertEnclosingClass && !!classThatEncloseTheVar) +
-          (insertEnclosingFunction && !!funcThatEncloseTheVar)
-      )
-      .map(value => `${quote}${value}${quote}`)
-      .join(", ");
+
+  const necessaryStyleCount =
+    (insertEnclosingClass && !!classThatEncloseTheVar) +
+    (insertEnclosingFunction && !!funcThatEncloseTheVar) +
+    1;
+  let formattedStylesString = "";
+  if (styleArray.length > 0) {
+    formattedStylesString += ", ";
+    if (styleArray.length > 1) {
+      formattedStylesString += styleArray
+        .slice(0, necessaryStyleCount + 1)
+        .map(value => `${quote}${value}${quote}`)
+        .join(", ");
+    } else {
+      formattedStylesString += `...Array(${necessaryStyleCount + 1}).fill("${
+        styleArray[0]
+      }")`;
+    }
+  }
+
   const lineOfLogMsg = logMessageLine(document, lineOfSelectedVar, selectedVar);
   const spacesBeforeMsg = spaces(document, lineOfSelectedVar, tabSize);
   const semicolon = addSemicolonInTheEnd ? ";" : "";
@@ -62,7 +71,9 @@ function message(
     insertEnclosingClass ? classThatEncloseTheVar : ""
   }${
     insertEnclosingFunction ? funcThatEncloseTheVar : ""
-  }${optionalStyleDirective}${selectedVar}${quote}${formattedStyleArray}, ${selectedVar})${semicolon}`;
+  }${optionalStyleDirective}${selectedVar}${
+    formattedStylesString ? " " : ""
+  }${quote}${formattedStylesString}, ${selectedVar})${semicolon}`;
   if (wrapLogMessage) {
     // 16 represents the length of console.log("");
     const wrappingMsg = `console.log(${quote}${logMessagePrefix}: ${"-".repeat(

--- a/package.json
+++ b/package.json
@@ -57,6 +57,15 @@
           ],
           "default": "\"",
           "description": "Double quotes, single quotes or backtick"
+        },
+        "turboConsoleLog.styleArray": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "An inline CSS style definition.\nMore info: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style"
+          },
+          "default": [],
+          "description": "Each CSS style will be applied to a part of the selector (max 3 items).\nMore info: https://developer.mozilla.org/en-US/docs/Web/API/console"
         }
       }
     },

--- a/turboConsoleLog.js
+++ b/turboConsoleLog.js
@@ -24,6 +24,7 @@ function activate(context) {
       const addSemicolonInTheEnd = config.addSemicolonInTheEnd || false;
       const insertEnclosingClass = config.insertEnclosingClass;
       const insertEnclosingFunction = config.insertEnclosingFunction;
+      const styleArray = config.styleArray;
       for (let index = 0; index < editor.selections.length; index++) {
         const selection = editor.selections[index];
         const selectedVar = document.getText(selection);
@@ -53,7 +54,8 @@ function activate(context) {
                 addSemicolonInTheEnd,
                 insertEnclosingClass,
                 insertEnclosingFunction,
-                tabSize
+                tabSize,
+                styleArray
               )
             );
           });
@@ -70,9 +72,11 @@ function activate(context) {
       }
       const tabSize = editor.options.tabSize;
       const document = editor.document;
+      const config = vscode.workspace.getConfiguration("turboConsoleLog");
       const logMessagePrefix =
-        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix ||
-        "TCL";
+        (config.styleArray.length ? "%c" : "") +
+        (vscode.workspace.getConfiguration("turboConsoleLog")
+          .logMessagePrefix || "TCL");
       const logMessages = logMessage.detectAll(
         document,
         tabSize,
@@ -101,9 +105,11 @@ function activate(context) {
       }
       const tabSize = editor.options.tabSize;
       const document = editor.document;
+      const config = vscode.workspace.getConfiguration("turboConsoleLog");
       const logMessagePrefix =
-        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix ||
-        "TCL";
+        (config.styleArray.length ? "%c" : "") +
+        (vscode.workspace.getConfiguration("turboConsoleLog")
+          .logMessagePrefix || "TCL");
       const logMessages = logMessage.detectAll(
         document,
         tabSize,
@@ -134,9 +140,11 @@ function activate(context) {
       }
       const tabSize = editor.options.tabSize;
       const document = editor.document;
+      const config = vscode.workspace.getConfiguration("turboConsoleLog");
       const logMessagePrefix =
-        vscode.workspace.getConfiguration("turboConsoleLog").logMessagePrefix ||
-        "TCL";
+        (config.styleArray.length ? "%c" : "") +
+        (vscode.workspace.getConfiguration("turboConsoleLog")
+          .logMessagePrefix || "TCL");
       const logMessages = logMessage.detectAll(
         document,
         tabSize,


### PR DESCRIPTION
I use this great extension daily, thanks for creating it. After I discovered that VSCode debug panel is horribly bland, I decided to implement #23. This allows you to add an array of CSS inline style declarations, applied to class, function and element names.

More info: https://developer.mozilla.org/en-US/docs/Web/API/console

I'm not sure how active this repo is, so I might add my [forked version to the marketplace](https://github.com/tuur29/vscode-turbo-console-log/releases/tag/v1.4.0-tuur29) when there's no reply after a while.

## Screenshots

Example configuration:
![image](https://user-images.githubusercontent.com/2472626/70270078-e0fce680-17a3-11ea-95b6-985589d0938e.png)


Example output:
![image](https://user-images.githubusercontent.com/2472626/70270085-e3f7d700-17a3-11ea-806a-71bae37e80b9.png)


Example result:
![image](https://user-images.githubusercontent.com/2472626/70269920-a004d200-17a3-11ea-8e3f-dacd18a9edd3.png)


