### PR TITLE
change the default delimiterInsideMessage to empty string

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,7 +175,7 @@ function getExtensionProperties(
   const insertEnclosingClass = workspaceConfig.insertEnclosingClass;
   const insertEnclosingFunction = workspaceConfig.insertEnclosingFunction;
   const quote = workspaceConfig.quote || '"';
-  const delimiterInsideMessage = workspaceConfig.delimiterInsideMessage || "~";
+  const delimiterInsideMessage = workspaceConfig.delimiterInsideMessage || "";
   const includeFileNameAndLineNum =
     workspaceConfig.includeFileNameAndLineNum || false;
   const extensionProperties: ExtensionProperties = {


### PR DESCRIPTION
at the moment empty string always defaults to `~`. That is not needed because that is the default in the package.json.
This default will only be used for people who remove the `~` from their config.