### PR TITLE
Extension ~ feature ~ file path and line number in log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Properties:
 
 - turboConsoleLog.includeFileNameAndLineNum (boolean): Whether to include the file name and the line number of the log message.
 
+- turboConsoleLog.includeFilePathAndLineNum (boolean): Whether to include the file path and the line number together that can be opened in the editor.
+
 - turboConsoleLog.quote (enum): Double quotes (""), single quotes ('') or backtick(``).
 
 A wrapped log message :

--- a/src/debug-message/index.ts
+++ b/src/debug-message/index.ts
@@ -20,6 +20,7 @@ export abstract class DebugMessage {
     insertEnclosingFunction: boolean,
     delemiterInsideMessage: string,
     includeFileNameAndLineNum: boolean,
+    includeFilePathAndLineNum: boolean,
     tabSize: number
   ): string;
   abstract line(

--- a/src/debug-message/js/index.ts
+++ b/src/debug-message/js/index.ts
@@ -1,4 +1,4 @@
-import { TextDocument, TextLine } from "vscode";
+import { TextDocument, TextLine, workspace } from "vscode";
 import { DebugMessage } from "..";
 import { BlockType, LocElement, Message } from "../../entities";
 import { LineCodeProcessing } from "../../line-code-processing";
@@ -19,6 +19,7 @@ export class JSDebugMessage extends DebugMessage {
     insertEnclosingFunction: boolean,
     delemiterInsideMessage: string,
     includeFileNameAndLineNum: boolean,
+    includeFilePathAndLineNum: boolean,
     tabSize: number
   ): string {
     const classThatEncloseTheVar: string = this.enclosingBlockName(
@@ -61,6 +62,12 @@ export class JSDebugMessage extends DebugMessage {
     }${
       includeFileNameAndLineNum
         ? `file: ${fileName} ${delemiterInsideMessage} line ${
+            lineOfLogMsg + 1
+          } ${delemiterInsideMessage} `
+        : ""
+    }${
+      includeFilePathAndLineNum
+        ? `${workspace.asRelativePath(document.fileName)}:${
             lineOfLogMsg + 1
           } ${delemiterInsideMessage} `
         : ""

--- a/src/entities/extensionProperties.ts
+++ b/src/entities/extensionProperties.ts
@@ -6,5 +6,6 @@ export type ExtensionProperties = {
   insertEnclosingFunction: boolean;
   delimiterInsideMessage: string;
   includeFileNameAndLineNum: boolean;
+  includeFilePathAndLineNum: boolean;
   quote: string;
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
                 properties.insertEnclosingFunction,
                 properties.delimiterInsideMessage,
                 properties.includeFileNameAndLineNum,
+                properties.includeFilePathAndLineNum,
                 tabSize
               )
             );
@@ -178,6 +179,8 @@ function getExtensionProperties(
   const delimiterInsideMessage = workspaceConfig.delimiterInsideMessage || "~";
   const includeFileNameAndLineNum =
     workspaceConfig.includeFileNameAndLineNum || false;
+  const includeFilePathAndLineNum =
+    workspaceConfig.includeFilePathAndLineNum || false;
   const extensionProperties: ExtensionProperties = {
     wrapLogMessage,
     logMessagePrefix,
@@ -187,6 +190,7 @@ function getExtensionProperties(
     quote,
     delimiterInsideMessage,
     includeFileNameAndLineNum,
+    includeFilePathAndLineNum,
   };
   return extensionProperties;
 }


### PR DESCRIPTION
Adds the option `includeFilePathAndLineNum` that includes the current file path relative to the workspace directory with the line number joined with a colon so that it can be opened in the editor.

Eg. if your current opened project is `/Users/user-name/Developer/turbo-console-log` and the file path is `/Users/user-name/Developer/turbo-console-log/src/test.ts` and you are on line 5 it will log `src/test.ts:5`. This way it can be opened in the editor and go directly to the logged line.

https://user-images.githubusercontent.com/63549997/126907632-9969a7a6-12bb-4163-9da7-64043285d350.mov

I could not run the tests because an ESlint config is missing? I don't really understand the test setup sorry. 😬
