### PR TITLE
Add hover word selection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,16 @@ export function activate(context: vscode.ExtensionContext) {
       const properties: ExtensionProperties = getExtensionProperties(config);
       for (let index = 0; index < editor.selections.length; index++) {
         const selection: vscode.Selection = editor.selections[index];
-        const selectedVar: string = document.getText(selection);
+        
+        let wordUnderCursor = "";
+        const rangeUnderCursor: vscode.Range | undefined = document.getWordRangeAtPosition(
+            selection.active
+        );
+        // if rangeUnderCursor is undefined, `document.getText(undefined)` will return the entire file.
+        if (rangeUnderCursor) {
+            wordUnderCursor = document.getText(rangeUnderCursor);
+        }
+        const selectedVar: string = document.getText(selection) || wordUnderCursor;
         const lineOfSelectedVar: number = selection.active.line;
         // Check if the selection line is not the last one in the document and the selected variable is not empty
         if (selectedVar.trim().length !== 0) {


### PR DESCRIPTION
* Add the ability to print directly the word under the cursor without a manual selection.
* Manual selection will always take over the hover selection.

![turbo_logger](https://user-images.githubusercontent.com/28490646/154867239-0bb87f40-faa8-4eab-b67c-9abf40937a3a.gif)

Potentially there could be a new settings that enables the print to include parent.child chain. Example:
Hovering over `foo` of `this.bar.foo` will automatically print `console.log(this.bar.foo)`