### PR TITLE
Added option for log type in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,18 @@
           ],
           "default": "\"",
           "description": "Double quotes, single quotes or backtick"
+        },
+        "turboConsoleLog.logType": {
+          "type": "string",
+          "enum": [
+            "log",
+            "warn",
+            "error",
+            "debug",
+            "table"
+          ],
+          "default": "log",
+          "description": "Select the log type"
         }
       }
     },

--- a/src/debug-message/index.ts
+++ b/src/debug-message/index.ts
@@ -21,7 +21,8 @@ export abstract class DebugMessage {
     insertEnclosingFunction: boolean,
     delemiterInsideMessage: string,
     includeFileNameAndLineNum: boolean,
-    tabSize: number
+    tabSize: number,
+    logType: string
   ): void;
   abstract line(
     document: TextDocument,

--- a/src/debug-message/js/index.ts
+++ b/src/debug-message/js/index.ts
@@ -21,7 +21,8 @@ export class JSDebugMessage extends DebugMessage {
     insertEnclosingFunction: boolean,
     delemiterInsideMessage: string,
     includeFileNameAndLineNum: boolean,
-    tabSize: number
+    tabSize: number,
+    logType: string
   ): void {
     const classThatEncloseTheVar: string = this.enclosingBlockName(
       document,
@@ -55,7 +56,7 @@ export class JSDebugMessage extends DebugMessage {
     ) {
       logMessagePrefix = `${delemiterInsideMessage} `;
     }
-    const debuggingMsg: string = `console.log(${quote}${logMessagePrefix}${
+    const debuggingMsg: string = `console.${logType}(${quote}${logMessagePrefix}${
       logMessagePrefix.length !== 0 &&
       logMessagePrefix !== `${delemiterInsideMessage} `
         ? ` ${delemiterInsideMessage} `
@@ -81,7 +82,7 @@ export class JSDebugMessage extends DebugMessage {
     }${selectedVar}${quote}, ${selectedVar})${semicolon}`;
     if (wrapLogMessage) {
       // 16 represents the length of console.log("");
-      const wrappingMsg: string = `console.log(${quote}${logMessagePrefix} ${"-".repeat(
+      const wrappingMsg: string = `console.${logType}(${quote}${logMessagePrefix} ${"-".repeat(
         debuggingMsg.length - 16
       )}${quote})${semicolon}`;
       textEditor.insert(

--- a/src/entities/extensionProperties.ts
+++ b/src/entities/extensionProperties.ts
@@ -7,4 +7,14 @@ export type ExtensionProperties = {
   delimiterInsideMessage: string;
   includeFileNameAndLineNum: boolean;
   quote: string;
+  logType: enumLogType;
 };
+
+enum enumLogType {
+  log = "log",
+  warn = "warn",
+  error = "error",
+  debug = "debug",
+  table = "table",
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,8 @@ export function activate(context: vscode.ExtensionContext) {
               properties.insertEnclosingFunction,
               properties.delimiterInsideMessage,
               properties.includeFileNameAndLineNum,
-              tabSize
+              tabSize,
+              properties.logType,
             );
           });
         }
@@ -167,6 +168,7 @@ function getExtensionProperties(
   const delimiterInsideMessage = workspaceConfig.delimiterInsideMessage || "~";
   const includeFileNameAndLineNum =
     workspaceConfig.includeFileNameAndLineNum || false;
+  const logType = workspaceConfig.logType || "log";
   const extensionProperties: ExtensionProperties = {
     wrapLogMessage,
     logMessagePrefix,
@@ -176,6 +178,7 @@ function getExtensionProperties(
     quote,
     delimiterInsideMessage,
     includeFileNameAndLineNum,
+    logType
   };
   return extensionProperties;
 }


### PR DESCRIPTION
In settings, you can select the log type like debug, log, info, warn, error or table, and while inserting the statement we are using the option selected by the end-user. By default, we have kept a log as input.