### PR TITLE
fix wrapLogMessage: true, repeat console.log(msg)

### DIFF
--- a/src/debug-message/js/index.ts
+++ b/src/debug-message/js/index.ts
@@ -95,35 +95,36 @@ export class JSDebugMessage extends DebugMessage {
           lineOfLogMsg === document.lineCount ? "\n" : ""
         }${spacesBeforeMsg}${wrappingMsg}\n${spacesBeforeMsg}${debuggingMsg}\n${spacesBeforeMsg}${wrappingMsg}\n`
       );
-    }
-    const previousMsgLogLine = document.lineAt(lineOfLogMsg - 1);
-    if (/\){.*}/.test(previousMsgLogLine.text.replace(/\s/g, ""))) {
-      const textBeforeClosedFunctionParenthesis =
-        previousMsgLogLine.text.split(")")[0];
-      textEditor.delete(previousMsgLogLine.rangeIncludingLineBreak);
-      textEditor.insert(
-        new vscode.Position(
-          lineOfLogMsg >= document.lineCount
-            ? document.lineCount
-            : lineOfLogMsg,
-          0
-        ),
-        `${textBeforeClosedFunctionParenthesis}){\n${
-          lineOfLogMsg === document.lineCount ? "\n" : ""
-        }${spacesBeforeMsg}${debuggingMsg}\n${spacesBeforeMsg}}\n`
-      );
     } else {
-      textEditor.insert(
-        new vscode.Position(
-          lineOfLogMsg >= document.lineCount
-            ? document.lineCount
-            : lineOfLogMsg,
-          0
-        ),
-        `${
-          lineOfLogMsg === document.lineCount ? "\n" : ""
-        }${spacesBeforeMsg}${debuggingMsg}\n`
-      );
+      const previousMsgLogLine = document.lineAt(lineOfLogMsg - 1);
+      if (/\){.*}/.test(previousMsgLogLine.text.replace(/\s/g, ""))) {
+        const textBeforeClosedFunctionParenthesis =
+          previousMsgLogLine.text.split(")")[0];
+        textEditor.delete(previousMsgLogLine.rangeIncludingLineBreak);
+        textEditor.insert(
+          new vscode.Position(
+            lineOfLogMsg >= document.lineCount
+              ? document.lineCount
+              : lineOfLogMsg,
+            0
+          ),
+          `${textBeforeClosedFunctionParenthesis}){\n${
+            lineOfLogMsg === document.lineCount ? "\n" : ""
+          }${spacesBeforeMsg}${debuggingMsg}\n${spacesBeforeMsg}}\n`
+        );
+      } else {
+        textEditor.insert(
+          new vscode.Position(
+            lineOfLogMsg >= document.lineCount
+              ? document.lineCount
+              : lineOfLogMsg,
+            0
+          ),
+          `${
+            lineOfLogMsg === document.lineCount ? "\n" : ""
+          }${spacesBeforeMsg}${debuggingMsg}\n`
+        );
+      }
     }
   }
   line(


### PR DESCRIPTION
Turbo Console Log v2.1.7

when set wrapLogMessage: true, always console.log(msg) twice !!!
Because wrapLogMessage and notWrapLogMessage all execute

Before:
```
if(wrapLogMessage) {
   ...
}
notWrapLogMessage...
```

After:
```
if(wrapLogMessage) {
   ...
} else {
   notWrapLogMessage...
}
```