### PR TITLE
Add optional postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Properties:
 
 - turboConsoleLog.logMessagePrefix (string): The prefix of the log message (default one is 🚀 ).
 
+- turboConsoleLog.logMessagePostfix (string): The postfix of the log message (default one is '' ).
+
 - turboConsoleLog.addSemicolonInTheEnd (boolean): Whether to put a semicolon in the end of the log message or not.
 
 - turboConsoleLog.insertEnclosingClass (boolean): Whether to insert or not the enclosing class of the selected variable in the log message.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
           "default": "🚀",
           "description": "The prefix of the log message."
         },
+        "turboConsoleLog.logMessagePostfix": {
+          "type": "string",
+          "default": "",
+          "description": "The postfix of the log message."
+        },
         "turboConsoleLog.includeFileNameAndLineNum": {
           "type": "boolean",
           "default": true,

--- a/src/debug-message/index.ts
+++ b/src/debug-message/index.ts
@@ -14,6 +14,7 @@ export abstract class DebugMessage {
     lineOfSelectedVar: number,
     wrapLogMessage: boolean,
     logMessagePrefix: string,
+    logMessagePostfix: string,
     quote: string,
     addSemicolonInTheEnd: boolean,
     insertEnclosingClass: boolean,

--- a/src/debug-message/js/index.ts
+++ b/src/debug-message/js/index.ts
@@ -15,6 +15,7 @@ export class JSDebugMessage extends DebugMessage {
     lineOfSelectedVar: number,
     wrapLogMessage: boolean,
     logMessagePrefix: string,
+    logMessagePostfix: string,
     quote: string,
     addSemicolonInTheEnd: boolean,
     insertEnclosingClass: boolean,
@@ -85,12 +86,12 @@ export class JSDebugMessage extends DebugMessage {
           ? `${funcThatEncloseTheVar} ${delemiterInsideMessage} `
           : ''
         : ''
-    }${selectedVar}${quote}, ${selectedVar})${semicolon}`;
+    }${selectedVar}${logMessagePostfix}${quote}, ${selectedVar})${semicolon}`;
     if (wrapLogMessage) {
       // 16 represents the length of console.log("");
       const wrappingMsg = `console.${logType}(${quote}${logMessagePrefix} ${'-'.repeat(
         debuggingMsg.length - 16,
-      )}${logMessagePrefix}${quote})${semicolon}`;
+      )}${logMessagePostfix}${quote})${semicolon}`;
       textEditor.insert(
         new vscode.Position(
           lineOfLogMsg >= document.lineCount

--- a/src/entities/extensionProperties.ts
+++ b/src/entities/extensionProperties.ts
@@ -1,6 +1,7 @@
 export type ExtensionProperties = {
   wrapLogMessage: boolean;
   logMessagePrefix: string;
+  logMessagePostfix: string;
   addSemicolonInTheEnd: boolean;
   insertEnclosingClass: boolean;
   insertEnclosingFunction: boolean;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
           const {
             wrapLogMessage,
             logMessagePrefix,
+            logMessagePostfix,
             quote,
             addSemicolonInTheEnd,
             insertEnclosingClass,
@@ -59,6 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
               lineOfSelectedVar,
               wrapLogMessage,
               logMessagePrefix,
+              logMessagePostfix,
               quote,
               addSemicolonInTheEnd,
               insertEnclosingClass,
@@ -193,6 +195,10 @@ function getExtensionProperties(
   const logMessagePrefix = workspaceConfig.logMessagePrefix
     ? workspaceConfig.logMessagePrefix
     : "";
+
+  const logMessagePostfix = workspaceConfig.logMessagePostfix
+    ? workspaceConfig.logMessagePostfix
+    : "";
   const addSemicolonInTheEnd = workspaceConfig.addSemicolonInTheEnd || false;
   const insertEnclosingClass = workspaceConfig.insertEnclosingClass;
   const insertEnclosingFunction = workspaceConfig.insertEnclosingFunction;
@@ -207,6 +213,7 @@ function getExtensionProperties(
   const extensionProperties: ExtensionProperties = {
     wrapLogMessage,
     logMessagePrefix,
+    logMessagePostfix,
     addSemicolonInTheEnd,
     insertEnclosingClass,
     insertEnclosingFunction,


### PR DESCRIPTION
feat: Add optional postfix for logging.

Reason: There's currently no way of adding postfix to every message and I don't want to wrap my logs. e.g

const test = 5;

Currently, there's no way to generate a log that differs from 'test5' - with this change I no longer have to manually insert a - or a space between test and 5

My first attempt to contribute to open source, looking forward to any feedback.
fix for github issues: [want postfix](https://github.com/Chakroun-Anas/turbo-console-log/issues/143), [Feature request: logMessageSuffix](https://github.com/Chakroun-Anas/turbo-console-log/issues/128) 