### PR TITLE
New Feature: User can choose delimiter between log message and variab…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Properties:
 
 - turboConsoleLog.delemiterInsideMessage (string): The delimiter that will separate the different log message elements (file name, line number, class, function and variable)
 
+- turboConsoleLog.delemiterOutsideMessage (string): The delimiter that will separate the log message from the variable outside the message.
+
 - turboConsoleLog.includeFileNameAndLineNum (boolean): Whether to include the file name and the line number of the log message.
 
 - turboConsoleLog.quote (enum): Double quotes (""), single quotes ('') or backtick(``).

--- a/package.json
+++ b/package.json
@@ -66,7 +66,12 @@
         "turboConsoleLog.delimiterInsideMessage": {
           "type": "string",
           "default": "~",
-          "description": "The delimiter that will separate the different log message elements (file name, line number, class, function and variable)"
+          "description": "The delimiter that will separate the different log message elements (file name, line number, class, function and variable)."
+        },
+        "turboConsoleLog.delimiterOutsideMessage": {
+          "type": "string",
+          "default": "~",
+          "description": "The delimiter that will separate the log message from the variable outside the message."
         },
         "turboConsoleLog.quote": {
           "type": "string",

--- a/src/debug-message/index.ts
+++ b/src/debug-message/index.ts
@@ -28,6 +28,7 @@ export abstract class DebugMessage {
   abstract detectAll(
     document: TextDocument,
     delemiterInsideMessage: string,
+    delimiterOutsideMessage: string,
     quote: string,
   ): Message[];
   abstract enclosingBlockName(

--- a/src/debug-message/js/index.ts
+++ b/src/debug-message/js/index.ts
@@ -190,7 +190,7 @@ export class JSDebugMessage extends DebugMessage {
           ? `${funcThatEncloseTheVar} ${extensionProperties.delimiterInsideMessage} `
           : ''
         : ''
-    }${selectedVar}${extensionProperties.quote}, ${selectedVar})${semicolon}`;
+    }${selectedVar} ${extensionProperties.quote} ${extensionProperties.delimiterOutsideMessage} ${selectedVar})${semicolon}`;
   }
   private anonymousPropDebuggingMsg(
     document: TextDocument,

--- a/src/entities/extensionProperties.ts
+++ b/src/entities/extensionProperties.ts
@@ -7,6 +7,7 @@ export type ExtensionProperties = {
   insertEmptyLineBeforeLogMessage: boolean;
   insertEmptyLineAfterLogMessage: boolean;
   delimiterInsideMessage: string;
+  delimiterOutsideMessage: string;
   includeFileNameAndLineNum: boolean;
   quote: string;
   logType: enumLogType;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ export function activate(context: vscode.ExtensionContext): void {
             insertEmptyLineBeforeLogMessage,
             insertEmptyLineAfterLogMessage,
             delimiterInsideMessage,
+            delimiterOutsideMessage,
             includeFileNameAndLineNum,
             logType,
             logFunction,
@@ -68,6 +69,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 insertEmptyLineBeforeLogMessage,
                 insertEmptyLineAfterLogMessage,
                 delimiterInsideMessage,
+                delimiterOutsideMessage,
                 includeFileNameAndLineNum,
                 logType,
                 logFunction,
@@ -95,6 +97,7 @@ export function activate(context: vscode.ExtensionContext): void {
       const logMessages: Message[] = jsDebugMessage.detectAll(
         document,
         properties.delimiterInsideMessage,
+        properties.delimiterOutsideMessage,
         properties.quote,
       );
       editor.edit((editBuilder) => {
@@ -127,6 +130,7 @@ export function activate(context: vscode.ExtensionContext): void {
       const logMessages: Message[] = jsDebugMessage.detectAll(
         document,
         properties.delimiterInsideMessage,
+        properties.delimiterOutsideMessage,
         properties.quote,
       );
       editor.edit((editBuilder) => {
@@ -159,6 +163,7 @@ export function activate(context: vscode.ExtensionContext): void {
       const logMessages: Message[] = jsDebugMessage.detectAll(
         document,
         properties.delimiterInsideMessage,
+        properties.delimiterOutsideMessage,
         properties.quote,
       );
       editor.edit((editBuilder) => {
@@ -204,6 +209,7 @@ function getExtensionProperties(
     workspaceConfig.insertEmptyLineAfterLogMessage;
   const quote = workspaceConfig.quote || '"';
   const delimiterInsideMessage = workspaceConfig.delimiterInsideMessage || '~';
+  const delimiterOutsideMessage= workspaceConfig.delimiterOutsideMessage || ',';
   const includeFileNameAndLineNum =
     workspaceConfig.includeFileNameAndLineNum || false;
   const logType = workspaceConfig.logType || 'log';
@@ -218,6 +224,7 @@ function getExtensionProperties(
     insertEmptyLineAfterLogMessage,
     quote,
     delimiterInsideMessage,
+    delimiterOutsideMessage,
     includeFileNameAndLineNum,
     logType,
     logFunction,


### PR DESCRIPTION
New Feature: User can choose delimiter between log message and variable (delimiterOutsideMessage Example: + for log.error) 

Like

log.error("file: index.ts ~ line 11 ~ BlockType, " + BlockType,);