### PR TITLE
Feature/add log message suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Initial release of Turbo Console Log
 
 - Support arrow function transformation
 
+### 2.6.0
+
+- Support adding log message suffix
+
 ## Participate
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Properties:
 
 - turboConsoleLog.logMessagePrefix (string): The prefix of the log message (default one is 🚀 ).
 
+- turboConsoleLog.logMessageSuffix (string): The suffix of the log message (default one is `:` ).
+
 - turboConsoleLog.addSemicolonInTheEnd (boolean): Whether to put a semicolon in the end of the log message or not.
 
 - turboConsoleLog.insertEnclosingClass (boolean): Whether to insert or not the enclosing class of the selected variable in the log message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turbo-console-log",
-  "version": "2.5.6",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turbo-console-log",
-      "version": "2.5.6",
+      "version": "2.6.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
           "default": "🚀",
           "description": "The prefix of the log message."
         },
+        "turboConsoleLog.logMessageSuffix": {
+          "type": "string",
+          "default": ":",
+          "description": "The suffix of the log message."
+        },
         "turboConsoleLog.includeFileNameAndLineNum": {
           "type": "boolean",
           "default": true,

--- a/src/debug-message/js/JSDebugMessage.ts
+++ b/src/debug-message/js/JSDebugMessage.ts
@@ -137,7 +137,7 @@ export class JSDebugMessage extends DebugMessage {
           ? `${funcThatEncloseTheVar} ${extensionProperties.delimiterInsideMessage} `
           : ''
         : ''
-    }${selectedVar}${extensionProperties.quote}, ${selectedVar})${semicolon}`;
+    }${selectedVar}${extensionProperties.logMessageSuffix}${extensionProperties.quote}, ${selectedVar})${semicolon}`;
   }
 
   private emptyBlockDebuggingMsg(

--- a/src/entities/extensionProperties.ts
+++ b/src/entities/extensionProperties.ts
@@ -1,6 +1,7 @@
 export type ExtensionProperties = {
   wrapLogMessage: boolean;
   logMessagePrefix: string;
+  logMessageSuffix: string;
   addSemicolonInTheEnd: boolean;
   insertEnclosingClass: boolean;
   insertEnclosingFunction: boolean;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,7 @@ function getExtensionProperties(
   return {
     wrapLogMessage: workspaceConfig.wrapLogMessage ?? false,
     logMessagePrefix: workspaceConfig.logMessagePrefix ?? '',
+    logMessageSuffix: workspaceConfig.logMessageSuffix ?? '',
     addSemicolonInTheEnd: workspaceConfig.addSemicolonInTheEnd ?? false,
     insertEnclosingClass: workspaceConfig.insertEnclosingClass ?? true,
     insertEnclosingFunction: workspaceConfig.insertEnclosingFunction ?? true,


### PR DESCRIPTION
New feature: Now users can decide whether to add a suffix to their log message or not. If opted in, they can set what the suffix can be; the default is set to be a `:`.