### PR TITLE
Feature/update line numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turbo-console-log",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turbo-console-log",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,10 @@
         "title": "Turbo Console Log: Uncomment All Log Messages"
       },
       {
+        "command": "turboConsoleLog.updateLogMessage",
+        "title": "Turbo Console Log: Update Log Messages at Selected Lines"
+      },
+      {
         "command": "turboConsoleLog.updateAllLogMessages",
         "title": "Turbo Console Log: Update All Log Messages"
       },

--- a/package.json
+++ b/package.json
@@ -116,6 +116,10 @@
         "title": "Turbo Console Log: Uncomment All Log Messages"
       },
       {
+        "command": "turboConsoleLog.updateAllLogMessages",
+        "title": "Turbo Console Log: Update All Log Messages"
+      },
+      {
         "command": "turboConsoleLog.deleteAllLogMessages",
         "title": "Turbo Console Log: Delete All Log Messages"
       }
@@ -150,7 +154,7 @@
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "watch": "npm run esbuild --watch",
     "lint": "eslint src --ext ts",
-    "pretest": "yarn run esbuild-base",
+    "pretest": "npm run esbuild-base",
     "test-compile": "rm -rf out && tsc -p ./ && mkdir out/test/files && cp -r src/test/files/ out/test/files/",
     "test": "npm run test-compile && node ./out/test/runTests.js",
     "test:unit": "npm run test-compile && mocha --require ts-node/register 'src/test/unit/**/*.test.ts'"

--- a/src/commands/commentAllLogMessages.ts
+++ b/src/commands/commentAllLogMessages.ts
@@ -33,12 +33,10 @@ export function commentAllLogMessagesCommand(): Command {
         return logFunction;
       }
 
-      const editor: vscode.TextEditor | undefined =
-        vscode.window.activeTextEditor;
-      if (!editor) {
-        return;
-      }
-      const document: vscode.TextDocument = editor.document;
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) return;
+
+      const document = editor.document;
       const logMessages: Message[] = jsDebugMessage.detectAll(
         document,
         logFunctionToUse(),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,12 +2,15 @@ import { displayLogMessageCommand } from './displayLogMessage';
 import { commentAllLogMessagesCommand } from './commentAllLogMessages';
 import { uncommentAllLogMessagesCommand } from './uncommentAllLogMessages';
 import { deleteAllLogMessagesCommand } from './deleteAllLogMessages';
+import { updateAllLogMessagesCommand } from './updateAllLogMessages';
 import { Command } from '../entities';
+
 export function getAllCommands(): Array<Command> {
   return [
     displayLogMessageCommand(),
     commentAllLogMessagesCommand(),
     uncommentAllLogMessagesCommand(),
     deleteAllLogMessagesCommand(),
+    updateAllLogMessagesCommand(),
   ];
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import { commentAllLogMessagesCommand } from './commentAllLogMessages';
 import { uncommentAllLogMessagesCommand } from './uncommentAllLogMessages';
 import { deleteAllLogMessagesCommand } from './deleteAllLogMessages';
 import { updateAllLogMessagesCommand } from './updateAllLogMessages';
+import { updateLogMessagesCommand } from './updateLogMessageComment';
 import { Command } from '../entities';
 
 export function getAllCommands(): Array<Command> {
@@ -12,5 +13,6 @@ export function getAllCommands(): Array<Command> {
     uncommentAllLogMessagesCommand(),
     deleteAllLogMessagesCommand(),
     updateAllLogMessagesCommand(),
+    updateLogMessagesCommand(),
   ];
 }

--- a/src/commands/updateAllLogMessages.ts
+++ b/src/commands/updateAllLogMessages.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import { DebugMessage } from '../debug-message';
+import { Command, ExtensionProperties, Message } from '../entities';
+import type { JSDebugMessage } from '../debug-message/js';
+
+export function updateAllLogMessagesCommand(): Command {
+  return {
+    name: 'turboConsoleLog.updateAllLogMessages',
+    handler: async (
+      {
+        delimiterInsideMessage,
+        logMessagePrefix,
+        logFunction,
+      }: ExtensionProperties,
+      jsDebugMessage: DebugMessage,
+      args?: unknown[],
+    ) => {
+      function logFunctionToUse(): string {
+        if (
+          args &&
+          args.length > 0 &&
+          typeof args[0] === 'object' &&
+          args[0] !== null
+        ) {
+          const firstArg = args[0] as Record<string, unknown>;
+          if (
+            'logFunction' in firstArg &&
+            typeof firstArg.logFunction === 'string'
+          ) {
+            return firstArg.logFunction;
+          }
+          return logFunction;
+        }
+        return logFunction;
+      }
+
+      const editor: vscode.TextEditor | undefined =
+        vscode.window.activeTextEditor;
+      if (!editor) {
+        return;
+      }
+      const document: vscode.TextDocument = editor.document;
+
+      const logMessages: Message[] = jsDebugMessage.detectAll(
+        document,
+        logFunctionToUse(),
+        logMessagePrefix,
+        delimiterInsideMessage,
+      );
+      console.log(
+        '🚀 ~ file: updateAllLogFMessages.ts:49 ~ updateAllLogMessagesCommand ~ logMessages:',
+        logMessages,
+      );
+
+      editor.edit((editBuilder) => {
+        logMessages.forEach(({ spaces, lines }) => {
+          lines.forEach((line: vscode.Range) => {
+            const prevLine = document.getText(line).trim();
+            const newLine = (
+              jsDebugMessage as JSDebugMessage
+            ).updateFileNameAndLineNum(prevLine, document, line.start.line + 1);
+            editBuilder.delete(line);
+            editBuilder.insert(
+              new vscode.Position(line.start.line, 0),
+              `${spaces}${newLine}\n`,
+            );
+          });
+        });
+      });
+    },
+  };
+}

--- a/src/debug-message/js/JSDebugMessage.ts
+++ b/src/debug-message/js/JSDebugMessage.ts
@@ -166,8 +166,6 @@ export class JSDebugMessage extends DebugMessage {
       props.logFunction !== 'log' ? props.logFunction : `console.${logType}`;
 
     let messageExpression = `${logFunc}(${quote}${message}${quote}, ${selectedVar})`;
-    //console.log( '🚀 ~ file: JSDebugMessage.ts:163 ~ messageExpression:', JSON.stringify(messageExpression), { logFunc, message, contents: JSON.stringify(contents), delimiter, quote, selectedVar, },);
-
     if (addSemicolonInTheEnd) {
       messageExpression += ';';
     }
@@ -324,8 +322,7 @@ export class JSDebugMessage extends DebugMessage {
     newLineNum: number,
   ): string {
     const newFileName = this.normalizeFilename(document.fileName);
-    return prevLine.replace(/file: ([^:]*?):([0-9]+)/, (..._matchData) => {
-      //const [prevFileName, prevLineNum] = matchData.slice(1);
+    return prevLine.replace(/file: ([^:]*?):([0-9]+)/, () => {
       return `file: ${newFileName}:${newLineNum}`;
     });
   }
@@ -348,15 +345,6 @@ export class JSDebugMessage extends DebugMessage {
       lineOfSelectedVar,
       selectedVar,
       logMsg,
-    );
-    console.log(
-      '🚀 ~ file: JSDebugMessage.ts:326 ~ .trim ~ lineOfLogMsg:',
-      lineOfLogMsg,
-      {
-        logMsg,
-        selectedVar,
-        lineOfSelectedVar,
-      },
     );
     const spacesBeforeMsg: string = this.spacesBeforeLogMsg(
       document,
@@ -663,7 +651,6 @@ export class JSDebugMessage extends DebugMessage {
       const { isChecked, metadata } =
         logMsgTypesChecks[logMessageType as keyof typeof logMsgTypesChecks]();
       if (logMessageType !== LogMessageType.PrimitiveAssignment && isChecked) {
-        //console.log( '🚀 ~ file: JSDebugMessage.ts:637 ~ logMessageType:', logMessageType, { isChecked, metadata },);
         return {
           logMessageType,
           metadata,
@@ -750,17 +737,7 @@ export class JSDebugMessage extends DebugMessage {
       logFunction.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
     );
 
-    const documentNbrOfLines: number = document.lineCount;
-    console.log(
-      '🚀 ~ file: JSDebugMessage.ts:726 ~ logFunction:',
-      documentNbrOfLines,
-      JSON.stringify(logFunction),
-      {
-        logMessagePrefix,
-        delimiterInsideMessage,
-      },
-    );
-
+    const documentNbrOfLines = document.lineCount;
     for (let i = 0; i < documentNbrOfLines; i++) {
       // skip if line does not contain any log function text
       if (!turboConsoleLogMessage.test(document.lineAt(i).text)) continue;
@@ -787,12 +764,6 @@ export class JSDebugMessage extends DebugMessage {
         new RegExp(delimiterInsideMessage).test(msg)
       ) {
         logMessages.push(logMessage);
-        console.log(
-          '🚀 ~ file: JSDebugMessage.ts:754 ~ logMessage:',
-          logMessages.length,
-          logMessage.lines.map(formatRange),
-          { logMessage },
-        );
       }
     }
 


### PR DESCRIPTION
This PR fixes #238 , by adding two new commands: "turboConsoleLog.updateAllLogMessages" and "turboConsoleLog.updateLogMessage".

<details>
<summary>Demo</summary>

![output](https://github.com/user-attachments/assets/87cf0ed6-b9ca-4343-b100-edf2aee9b882)


</details>

The former detects all log messages (by calling the `.detectAll()` method), and replace the line with the new updated line. The `.updateFileNameAndLineNum()` method in `JSDebugMessage` class does a simple regex change.
The latter limits the update only to the lines in the `editor.selections`.

There are no tests, and it is a bit naive at the moment. If you are more interested, I can dive into the test codes as well. Feel free to leave a comment.

Thanks.

