### PR TITLE
Configuration to opt-out from What's New

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "type": "string",
           "default": "log",
           "description": "Specify a log function (when specified logType will be ignored)"
+        },
+        "turboConsoleLog.disableWhatsNew": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable the What's New notification and WebView after updating to a new version"
         }
       }
     },

--- a/src/entities/extension/extensionProperties.ts
+++ b/src/entities/extension/extensionProperties.ts
@@ -13,6 +13,7 @@ export type ExtensionProperties = {
   quote: string;
   logType: enumLogType;
   logFunction: string;
+  disableWhatsNew: boolean;
 };
 
 enum enumLogType {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ function getExtensionProperties(
     includeFilename: workspaceConfig.includeFilename ?? false,
     logType: workspaceConfig.logType ?? 'log',
     logFunction: workspaceConfig.logFunction ?? 'log',
+    disableWhatsNew: workspaceConfig.disableWhatsNew ?? false,
   };
 }
 
@@ -73,6 +74,10 @@ function getExtensionProperties(
 function showReleaseHtmlWebViewAndNotification(
   context: vscode.ExtensionContext,
 ): void {
+  const config: vscode.WorkspaceConfiguration =
+    vscode.workspace.getConfiguration('turboConsoleLog');
+  if (getExtensionProperties(config).disableWhatsNew) return;
+
   const wasNotificationShown = readFromGlobalState(
     context,
     `IS_NOTIFICATION_SHOWN_${latestReleaseVersion}`,


### PR DESCRIPTION
Adds a `disableWhatsNew` boolean configuration to disable the new version notifications.