### PR TITLE
Broken links to the license have been fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ It allows free personal and non-commercial use of the open-source core.
 
 Commercial use, redistribution, and use of the brand, logo, or Turbo Pro features are strictly protected.
 
-See the full **[LICENSE](./LICENSE.txt)** for details.
+See the full **[LICENSE](./LICENSE.TXT.** for details.

--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ It allows free personal and non-commercial use of the open-source core.
 
 Commercial use, redistribution, and use of the brand, logo, or Turbo Pro features are strictly protected.
 
-See the full **[LICENSE](./LICENSE.TXT.** for details.
+See the full **[LICENSE](./LICENSE.TXT).** for details.


### PR DESCRIPTION
The license file name listed in the README was incorrect, so I have corrected it.