### PR TITLE
docs: add quick test example and guidance for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,72 @@
+# Copilot / AI Agent Instructions — Turbo Console Log
+
+Short, actionable guidance to get productive quickly in this repo.
+
+## Quick facts ✅
+- Type: VS Code extension (TypeScript). Entry: `src/extension.ts` -> bundled to `out/extension.js` via `esbuild`.
+- Build: `npm run esbuild` (or `npm run watch` for dev). Prepublish: `npm run vscode:prepublish`.
+- Tests: `npm run test` (runs `jest` unit tests then mocha integration tests with `vscode-test`).
+- Lint/typecheck: `npm run lint` (runs `tsc` and `eslint`).
+
+## Where to start (high-value files) 🔍
+- Extension bootstrap: `src/extension.ts` (registers commands, webviews, pro bundle logic).
+- Commands: `src/commands/*` — each command exports a factory returning a `Command` with a `handler` (pattern to follow when adding commands).
+- Language-specific message builders & detectors: `src/debug-message/*` (e.g. `src/debug-message/js/JSDebugMessage/`).
+- Pro & bundle logic: `src/pro/` and `src/pro/utilities.ts` (functions `runProBundle`, `updateProBundle` and `activateRepairMode`).
+- Telemetry & notifications: `src/telemetry/*` and `src/notifications/*` (telemetry can be toggled via `turboConsoleLog.isTurboTelemetryEnabled`).
+- Tests:
+  - Unit: `src/jest-tests/**` (Jest config lives in `jest.config.ts`, aliases `@/` -> `src/`).
+  - Integration: `src/mocha-tests/**` (uses `vscode-test`). Note: `src/mocha-tests/runTests.ts` hardcodes `platform = 'darwin-arm64'` — change for other platforms.
+
+## Project-specific patterns & conventions 🧭
+- Commands registration: use `getAllCommands()` and return `Command` instances from `src/commands/*`.
+- Dependency on extension settings is passed as an `ExtensionProperties` object built in `src/extension.ts` via `getExtensionProperties(config)`.
+- Language abstraction: `DebugMessage` interface used to implement `msg` (insert) and `detectAll` (find logs) per-language. Add a new language by implementing this interface in `src/debug-message/<lang>/` and wire it into `src/extension.ts` and helpers.
+- Turbo-generated logs identification: Turbo marks logs using two settings: `turboConsoleLog.logMessagePrefix` and `turboConsoleLog.delimiterInsideMessage`. Detection uses fast regex + document parsing in `src/debug-message/js/JSDebugMessage/detectAll.ts` — look there when modifying detection.
+- PHP support: PHP message builder is loaded from the Pro bundle (`loadPhpDebugMessage(context)`) — adding PHP features may require Pro bundle changes instead of core JS/TS code.
+
+## Tests & CI notes ⚙️
+- `npm run test` flow:
+  1. `npm run test:compile` (tsc compile + copies `src/mocha-tests/files` into `out/mocha-tests/files`)
+  2. `npm run test:jest` (unit tests)
+  3. `node ./out/mocha-tests/runTests.js` (integration tests run with `vscode-test`).
+- If running mocha integration tests locally, update `src/mocha-tests/runTests.ts` `platform` and `vscodeVersion` as needed for your environment.
+- Jest uses module mappings for `vscode` and `p-limit` (see `jest.config.ts`). Add mocks under `src/jest-tests/mocks/` when testing VS Code interactions.
+
+## Known quirks & gotchas ⚠️
+- `dependencies` contains a local tarball reference (`@sveltejs/acorn-typescript` via `file:../../acorn-typescript/...`). Fresh clones may need that tarball or to replace the dependency with a published package.
+- Integration tests assume an environment with VS Code test runner; platform is hardcoded (see above).
+- Telemetry is enabled by default (setting `turboConsoleLog.isTurboTelemetryEnabled`); test suites assert telemetry behaviour in `src/jest-tests/unit/telemetry/telemetryService.test.ts`.
+
+## How to add a feature (quick checklist) 📝
+1. Add command factory in `src/commands/` and export via `getAllCommands()`.
+2. Use `ExtensionProperties` for config values; prefer passing `extensionProperties` to handlers.
+3. For language behavior, add/extend `DebugMessage` implementation under `src/debug-message/<lang>/` and update detection if necessary.
+4. Add unit tests in `src/jest-tests/` (mock `vscode` for logic-level tests). For behaviour that requires the VS Code host, add integration tests under `src/mocha-tests/`.
+5. Run `npm run lint` and `npm run test` before raising PR.
+
+## Files to check for examples
+- Insertion implementation: `src/debug-message/js/JSDebugMessage/msg/` (shows how log string is constructed).
+- Detection logic: `src/debug-message/js/JSDebugMessage/detectAll.ts` (fast regex pre-filter + document parsing).
+- Command pattern: `src/commands/insertConsoleLog.ts` (typical command handler).
+
+## Quick test example (copy-paste) ✅
+Use this as a starting point for small unit tests. It follows existing repo conventions (see `src/jest-tests/unit/**`).
+
+```ts
+import * as fs from 'fs';
+import { detectAll } from '@/debug-message/js/JSDebugMessage/detectAll/detectAll';
+import { mockedVscode } from '../../mocks/vscode'; // repo provides vscode mocks
+
+test('detectAll returns empty when no logs are present', async () => {
+  jest.spyOn(fs.promises, 'readFile' as any).mockResolvedValue('const a = 1;');
+  const vscode = mockedVscode();
+  const result = await detectAll(fs, vscode, '/path/to/file.js', 'log', '🚀', '~');
+  expect(result).toEqual([]);
+});
+```
+
+See `src/jest-tests/unit/js/JSDebugMessage/detectAll/detectAll.test.ts` for extensive test patterns and mocking examples.
+
+---
+If anything here is unclear or you want more detail for a particular area (testing, adding a language, or Pro bundle workflow), tell me which part to expand and I’ll iterate. Thanks!

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,22 @@ it('calls debugMessage.msg when inserting a log', async () => {
 });
 ```
 
-**Integration test note** — mocha integration tests use `vscode-test` and `src/mocha-tests/runTests.ts` sets `platform` (default: `darwin-arm64`) and `vscodeVersion`. Update those for your CI/local environment.
+**Integration test note** — mocha integration tests use `vscode-test`. `src/mocha-tests/runTests.ts` now respects environment variables to make CI easier:
+
+- `VSCODE_TEST_PLATFORM` (e.g., `darwin-x64`, `darwin-arm64`, `linux-x64`)
+- `VSCODE_TEST_VERSION` (e.g., `stable`)
+
+Run integration tests locally or in CI with:
+
+```bash
+export VSCODE_TEST_PLATFORM=linux-x64
+export VSCODE_TEST_VERSION=stable
+npm run test:compile && node ./out/mocha-tests/runTests.js
+```
+
+CI workflow example is provided in `.github/workflows/ci.yml` and runs lint+unit tests on Linux, and integration tests on macOS & Linux (sets platform via env).
+
+**Sample mock file** — see `src/jest-tests/mocks/axios.ts` for a jest-style `axios` mock (exported as default). Use `jest.mock('axios')` in tests or import this mock directly when needed.
 
 See `src/jest-tests/unit/js/JSDebugMessage/detectAll/detectAll.test.ts` for extensive test patterns and mocking examples.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,6 +110,8 @@ npm run test:compile && node ./out/mocha-tests/runTests.js
 
 CI workflow example is provided in `.github/workflows/ci.yml` and runs lint+unit tests on Linux, and integration tests on macOS & Linux (sets platform via env).
 
+**Coverage** — run Jest coverage locally with `npm run test:jest:coverage` (produces `coverage/lcov.info`). The CI uploads this file to Codecov using `codecov/codecov-action@v4`; after the first successful run the Codecov badge in the `README` will reflect coverage.
+
 **Sample mock file** — see `src/jest-tests/mocks/axios.ts` for a jest-style `axios` mock (exported as default). Use `jest.mock('axios')` in tests or import this mock directly when needed.
 
 See `src/jest-tests/unit/js/JSDebugMessage/detectAll/detectAll.test.ts` for extensive test patterns and mocking examples.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,6 +112,19 @@ CI workflow example is provided in `.github/workflows/ci.yml` and runs lint+unit
 
 **Coverage** — run Jest coverage locally with `npm run test:jest:coverage` (produces `coverage/lcov.info`). The CI uploads this file to Codecov using `codecov/codecov-action@v4`; after the first successful run the Codecov badge in the `README` will reflect coverage.
 
+Open the generated HTML coverage report locally (choose one):
+
+- macOS: `npm run test:jest:coverage && open ./coverage/lcov-report/index.html`
+- Linux: `npm run test:jest:coverage && xdg-open ./coverage/lcov-report/index.html`
+- Windows (PowerShell): `npm run test:jest:coverage; Start-Process ./coverage/lcov-report/index.html`
+
+If you don't have a system opener, serve it on a local port:
+
+```bash
+npm run test:jest:coverage && npx http-server ./coverage/lcov-report -p 8080
+# then open http://localhost:8080 in your browser
+```
+
 **Sample mock file** — see `src/jest-tests/mocks/axios.ts` for a jest-style `axios` mock (exported as default). Use `jest.mock('axios')` in tests or import this mock directly when needed.
 
 See `src/jest-tests/unit/js/JSDebugMessage/detectAll/detectAll.test.ts` for extensive test patterns and mocking examples.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,25 @@ jobs:
       - name: Run Jest unit tests
         run: npm run test:jest
 
+  coverage:
+    runs-on: ubuntu-latest
+    needs: lint-and-unit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Jest with coverage
+        run: npm run test:jest:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true
+
   integration-macos:
     runs-on: macos-latest
     needs: lint-and-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint-and-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint & Type-check
+        run: npm run lint
+      - name: Run Jest unit tests
+        run: npm run test:jest
+
+  integration-macos:
+    runs-on: macos-latest
+    needs: lint-and-unit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile tests
+        run: npm run test:compile
+      - name: Run integration tests (macOS)
+        env:
+          VSCODE_TEST_PLATFORM: darwin-x64
+          VSCODE_TEST_VERSION: stable
+        run: node ./out/mocha-tests/runTests.js
+
+  integration-linux:
+    runs-on: ubuntu-latest
+    needs: lint-and-unit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile tests
+        run: npm run test:compile
+      - name: Run integration tests (linux)
+        env:
+          VSCODE_TEST_PLATFORM: linux-x64
+          VSCODE_TEST_VERSION: stable
+        run: node ./out/mocha-tests/runTests.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turbo Console Log
 
-[![CI](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml/badge.svg)](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml)
+[![CI](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml/badge.svg)](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml) [![Coverage Status](https://codecov.io/gh/Chakroun-Anas/turbo-console-log/branch/master/graph/badge.svg)](https://codecov.io/gh/Chakroun-Anas/turbo-console-log)
 
 **[Official Website](https://www.turboconsolelog.io)** | **[Turbo Pro](https://www.turboconsolelog.io/pro)** | **[GitHub Repository](https://github.com/Chakroun-Anas/turbo-console-log)**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Turbo Console Log
 
+[![CI](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml/badge.svg)](https://github.com/Chakroun-Anas/turbo-console-log/actions/workflows/ci.yml)
+
 **[Official Website](https://www.turboconsolelog.io)** | **[Turbo Pro](https://www.turboconsolelog.io/pro)** | **[GitHub Repository](https://github.com/Chakroun-Anas/turbo-console-log)**
 
 ---
@@ -163,6 +165,33 @@ Your support keeps the project alive, funds new features, and helps us build too
 **Support:** **[support@turboconsolelog.io](mailto:support@turboconsolelog.io)**  
 **Feedback:** **[feedback@turboconsolelog.io](mailto:feedback@turboconsolelog.io)**  
 **Sponsorship:** **[sponsorship@turboconsolelog.io](mailto:sponsorship@turboconsolelog.io)**
+
+---
+
+## Run CI locally
+
+You can reproduce the CI steps locally with these commands (Node.js 20 recommended):
+
+```bash
+# install deps
+npm ci
+
+# lint and unit tests
+npm run lint
+npm run test:jest
+
+# compile tests for integration runner
+npm run test:compile
+
+# run integration tests (adjust platform/version as needed)
+export VSCODE_TEST_PLATFORM=linux-x64    # or darwin-x64 / darwin-arm64
+export VSCODE_TEST_VERSION=stable
+node ./out/mocha-tests/runTests.js
+```
+
+Notes:
+- Integration tests require VS Code test runner and platform-specific resources; macOS runners may be required for macOS-specific features.
+- Use `VSCODE_TEST_PLATFORM`/`VSCODE_TEST_VERSION` to match your local environment or CI.
 
 ---
 

--- a/src/jest-tests/mocks/axios.ts
+++ b/src/jest-tests/mocks/axios.ts
@@ -1,0 +1,7 @@
+const axios = {
+  get: jest.fn(),
+  post: jest.fn(),
+  create: () => axios,
+};
+
+export default axios;

--- a/src/jest-tests/unit/js/JSDebugMessage/detectAll/quickExample.test.ts
+++ b/src/jest-tests/unit/js/JSDebugMessage/detectAll/quickExample.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import { detectAll } from '@/debug-message/js/JSDebugMessage/detectAll/detectAll';
+import { mockedVscode } from '@/jest-tests/mocks/vscode';
+
+jest.mock('fs', () => ({
+  promises: { readFile: jest.fn() },
+}));
+
+const mockFsReadFile = fs.promises.readFile as jest.MockedFunction<
+  typeof fs.promises.readFile
+>;
+
+describe('detectAll quick example', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty array when file has no logs (fast prefilter)', async () => {
+    mockFsReadFile.mockResolvedValue('const a = 1;');
+    const vscode = mockedVscode();
+
+    const result = await detectAll(
+      fs,
+      vscode,
+      '/path/to/file.js',
+      'log',
+      '🚀',
+      '~',
+    );
+
+    expect(result).toEqual([]);
+    expect(mockFsReadFile).toHaveBeenCalledWith('/path/to/file.js', 'utf8');
+  });
+});

--- a/src/mocha-tests/files/js/log-feature/quickIntegration.ts
+++ b/src/mocha-tests/files/js/log-feature/quickIntegration.ts
@@ -1,0 +1,4 @@
+export function quickIntegration() {
+  const x = 1;
+  return x;
+}

--- a/src/mocha-tests/integration/js/log-feature/quickIntegration.ts
+++ b/src/mocha-tests/integration/js/log-feature/quickIntegration.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import Mocha, { it, describe } from 'mocha';
+import { expect } from 'chai';
+import {
+  openDocument,
+  expectActiveTextEditorWithFile,
+  documentLinesChanged,
+  NaturalEditorPosition,
+  naturalEditorLine,
+} from '../../../helpers';
+import { ProgrammingLanguage } from '../../../../../entities';
+
+export default (): void => {
+  describe('Quick integration scaffold', () => {
+    Mocha.beforeEach(async () => {
+      await openDocument(
+        ProgrammingLanguage.JAVASCRIPT,
+        'log-feature',
+        'quickIntegration.ts',
+      );
+    });
+    Mocha.afterEach(async () => {
+      await vscode.commands.executeCommand('workbench.action.closeActiveEditor', []);
+    });
+
+    it('Should insert a console.log for a simple variable', async () => {
+      const { activeTextEditor } = vscode.window;
+      expectActiveTextEditorWithFile(activeTextEditor, 'quickIntegration.ts');
+      if (activeTextEditor) {
+        // select the const x variable name
+        activeTextEditor.selections = [
+          new vscode.Selection(
+            new NaturalEditorPosition(0, 9),
+            new NaturalEditorPosition(0, 10),
+          ),
+        ];
+        await vscode.commands.executeCommand('turboConsoleLog.insertConsoleLog', []);
+        await Promise.all(documentLinesChanged(activeTextEditor.document, [naturalEditorLine(1)]));
+        const textDocument = activeTextEditor.document;
+        const logMessage = textDocument.lineAt(naturalEditorLine(1)).text;
+        expect(/console\.log\(.*/.test(logMessage)).to.equal(true);
+      }
+    });
+  });
+};

--- a/src/mocha-tests/runTests.ts
+++ b/src/mocha-tests/runTests.ts
@@ -6,8 +6,12 @@ async function main() {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../');
     const extensionTestsPath = path.resolve(__dirname, './testsRunner');
 
-    const vscodeVersion = 'stable';
-    const platform = 'darwin-arm64';
+    // Allow CI and local overrides via environment variables for flexibility
+    // Examples:
+    //  VSCODE_TEST_VERSION=stable
+    //  VSCODE_TEST_PLATFORM=linux-x64
+    const vscodeVersion = process.env.VSCODE_TEST_VERSION || 'stable';
+    const platform = process.env.VSCODE_TEST_PLATFORM || 'darwin-arm64';
 
     await runTests({
       version: vscodeVersion,


### PR DESCRIPTION
Adds a concise 'Quick test example' (copy-paste) to .github/copilot-instructions.md to help AI agents and contributors get started with repository tests, and updates guidance on where to add features and tests.\n\nSee: src/jest-tests/unit/js/JSDebugMessage/detectAll/detectAll.test.ts for more examples.